### PR TITLE
Automate publishing of Raycast extension

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish Raycast Extension
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Publish extension
+        run: npm run publish

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 ## Append to Clipboard
 
 The `Append to Clipboard` command reads the current clipboard from the Raycast clipboard history, copies the currently selected text, and combines the two with a newline character between them.
+
+## Publishing
+
+To publish the extension as a Raycast extension, follow these steps:
+
+1. Make sure you have the Raycast CLI installed. You can install it by running `npm install -g @raycast/cli`.
+2. Run `npm run publish` to publish the extension.
+3. The extension will be published to the Raycast store.
+
+Alternatively, you can set up GitHub Actions to automate the publishing process. A sample workflow file is provided in `.github/workflows/publish.yml`.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "description": "Dave Raycast Tools",
   "main": "index.js",
   "scripts": {
-    "appendToClipboard": "node src/commands/appendToClipboard.ts"
+    "appendToClipboard": "node src/commands/appendToClipboard.ts",
+    "publish": "raycast publish"
   },
   "dependencies": {
     "@raycast/api": "^1.0.0"
+  },
+  "devDependencies": {
+    "@raycast/cli": "^1.0.0"
   }
 }


### PR DESCRIPTION
Add configuration to publish as a Raycast extension on push to main.

* **package.json**
  - Add a new script `publish` to publish the extension using `raycast publish`.
  - Add `@raycast/cli` as a dev dependency.

* **.github/workflows/publish.yml**
  - Create a new GitHub Actions workflow file to automate publishing on push to main.
  - Use `actions/checkout@v2` to check out the repository.
  - Use `actions/setup-node@v2` to set up Node.js.
  - Run `npm install` to install dependencies.
  - Run `npm run publish` to publish the extension.

* **README.md**
  - Add a section "Publishing" with instructions on how to publish the extension.
  - Include steps for manual publishing and setting up GitHub Actions for automated publishing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dhoulb/raycast-tools/pull/1?shareId=839e2781-2fd1-433f-a7d2-cd21f95f3b9b).